### PR TITLE
Added Python3 support

### DIFF
--- a/Python/RandomNumberGenerator.py
+++ b/Python/RandomNumberGenerator.py
@@ -1,2 +1,2 @@
 import random       #importing random library
-print random.randint(0, 100)        #this will print a random number between 0, 100
+print(random.randint(0, 100))         #this will print a random number between 0, 100


### PR DESCRIPTION
print() function requires the use of brackets in Python3. Since Python 2 will not be widely supported soon, hence I added brackets to the print function